### PR TITLE
Update properties file to add logo field to display property

### DIFF
--- a/certify-mock-identity.properties
+++ b/certify-mock-identity.properties
@@ -35,6 +35,8 @@ mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Mock Verifiable Credential',\
     'locale': 'en'\
+    'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
+         'alt_text':'mosip-logo'}\
   }\
 }
 mosip.certify.indexed-mappings.email=$.email

--- a/certify-mock-identity.properties
+++ b/certify-mock-identity.properties
@@ -34,7 +34,7 @@ mosip.certify.cache.redis.key-prefix=${mosip.injicertify.mock.host}::
 mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Mock Verifiable Credential',\
-    'locale': 'en'\
+    'locale': 'en',\
     'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
          'alt_text':'mosip-logo'}\
   }\

--- a/certify-mock-mdl.properties
+++ b/certify-mock-mdl.properties
@@ -25,7 +25,7 @@ mosip.kernel.keymanager.hsm.keystore-pass=${softhsm.certify.mdl.security.pin:${s
 mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Mock Mobile Driving License',\
-    'locale': 'en'\
+    'locale': 'en',\
     'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
          'alt_text':'mosip-logo'}\
   }\

--- a/certify-mock-mdl.properties
+++ b/certify-mock-mdl.properties
@@ -26,6 +26,8 @@ mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Mock Mobile Driving License',\
     'locale': 'en'\
+    'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
+         'alt_text':'mosip-logo'}\
   }\
 }
 # Override proof types supported for the credential config

--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -40,7 +40,7 @@ mosip.kernel.keymanager.hsm.keystore-pass=${softhsm.certify.mosipid.security.pin
 mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'MOSIP National ID',\
-    'locale': 'en'\
+    'locale': 'en',\
     'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
          'alt_text':'mosip-logo'}\
   }\

--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -41,6 +41,8 @@ mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'MOSIP National ID',\
     'locale': 'en'\
+    'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
+         'alt_text':'mosip-logo'}\
   }\
 }
 # Override proof types supported for the credential config

--- a/certify-postgres-landregistry.properties
+++ b/certify-postgres-landregistry.properties
@@ -47,6 +47,8 @@ mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Cadastro Ambiental Rural',\
     'locale': 'en'\
+    'logo':{'url':'https://inji.github.io/inji-config/logos/agro-vertias-logo.png',\
+         'alt_text':'land-logo'}\
   }\
 }
 

--- a/certify-postgres-landregistry.properties
+++ b/certify-postgres-landregistry.properties
@@ -46,7 +46,7 @@ mosip.certify.cache.redis.key-prefix=${mosip.injicertify.landregistry.host}::
 mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Cadastro Ambiental Rural',\
-    'locale': 'en'\
+    'locale': 'en',\
     'logo':{'url':'https://inji.github.io/inji-config/logos/agro-vertias-logo.png',\
          'alt_text':'land-logo'}\
   }\

--- a/certify-sunbird-insurance.properties
+++ b/certify-sunbird-insurance.properties
@@ -45,6 +45,8 @@ mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Insurance',\
     'locale': 'en'\
+    'logo':{'url':'https://inji.github.io/inji-config/logos/StayProtectedInsurance.png',\
+         'alt_text':'a square logo of a Sunbird'}\
   }\
 }
 

--- a/certify-sunbird-insurance.properties
+++ b/certify-sunbird-insurance.properties
@@ -44,7 +44,7 @@ mosip.certify.cache.redis.key-prefix=${mosip.injicertify.insurance.host}::
 mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Insurance',\
-    'locale': 'en'\
+    'locale': 'en',\
     'logo':{'url':'https://inji.github.io/inji-config/logos/StayProtectedInsurance.png',\
          'alt_text':'a square logo of a Sunbird'}\
   }\


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Issuer logos now configured and displayed for all credential types, including mock identity, mobile driving license, MOSIP ID, land registry, and insurance credentials. Each issuer displays an associated logo with descriptive alt text for improved visual identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->