### PR TITLE
Update properties file to add logo field to display property

### DIFF
--- a/certify-mock-identity.properties
+++ b/certify-mock-identity.properties
@@ -35,6 +35,8 @@ mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Mock Verifiable Credential',\
     'locale': 'en'\
+    'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
+         'alt_text':'mosip-logo'}\
   }\
 }
 mosip.certify.indexed-mappings.email=$.email

--- a/certify-mock-identity.properties
+++ b/certify-mock-identity.properties
@@ -34,7 +34,7 @@ mosip.certify.cache.redis.key-prefix=${mosip.injicertify.mock.host}::
 mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Mock Verifiable Credential',\
-    'locale': 'en'\
+    'locale': 'en',\
     'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
          'alt_text':'mosip-logo'}\
   }\

--- a/certify-mock-mdl.properties
+++ b/certify-mock-mdl.properties
@@ -26,6 +26,8 @@ mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Mock Mobile Driving License',\
     'locale': 'en'\
+    'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
+         'alt_text':'mosip-logo'}\
   }\
 }
 

--- a/certify-mock-mdl.properties
+++ b/certify-mock-mdl.properties
@@ -25,7 +25,7 @@ mosip.kernel.keymanager.hsm.keystore-pass=${softhsm.certify.mdl.security.pin:${s
 mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Mock Mobile Driving License',\
-    'locale': 'en'\
+    'locale': 'en',\
     'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
          'alt_text':'mosip-logo'}\
   }\

--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -62,7 +62,7 @@ mosip.kernel.keymanager.hsm.keystore-pass=${softhsm.certify.mosipid.security.pin
 mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'MOSIP National ID',\
-    'locale': 'en'\
+    'locale': 'en',\
     'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
          'alt_text':'mosip-logo'}\
   }\

--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -63,6 +63,8 @@ mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'MOSIP National ID',\
     'locale': 'en'\
+    'logo':{'url':'https://inji.github.io/inji-config/logos/mosipid-logo.png',\
+         'alt_text':'mosip-logo'}\
   }\
 }
 # Override proof types supported for the credential config 

--- a/certify-postgres-landregistry.properties
+++ b/certify-postgres-landregistry.properties
@@ -47,6 +47,8 @@ mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Cadastro Ambiental Rural',\
     'locale': 'en'\
+    'logo':{'url':'https://inji.github.io/inji-config/logos/agro-vertias-logo.png',\
+         'alt_text':'land-logo'}\
   }\
 }
 

--- a/certify-postgres-landregistry.properties
+++ b/certify-postgres-landregistry.properties
@@ -46,7 +46,7 @@ mosip.certify.cache.redis.key-prefix=${mosip.injicertify.landregistry.host}::
 mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Cadastro Ambiental Rural',\
-    'locale': 'en'\
+    'locale': 'en',\
     'logo':{'url':'https://inji.github.io/inji-config/logos/agro-vertias-logo.png',\
          'alt_text':'land-logo'}\
   }\

--- a/certify-sunbird-insurance.properties
+++ b/certify-sunbird-insurance.properties
@@ -41,7 +41,7 @@ mosip.kernel.keymanager.hsm.keystore-pass=${softhsm.certify.insurance.security.p
 mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Insurance',\
-    'locale': 'en'\
+    'locale': 'en',\
     'logo':{'url':'https://inji.github.io/inji-config/logos/StayProtectedInsurance.png',\
          'alt_text':'a square logo of a Sunbird'}\
   }\

--- a/certify-sunbird-insurance.properties
+++ b/certify-sunbird-insurance.properties
@@ -42,6 +42,8 @@ mosip.certify.credential-config.issuer.display={\
   {\
     'name': 'Insurance',\
     'locale': 'en'\
+    'logo':{'url':'https://inji.github.io/inji-config/logos/StayProtectedInsurance.png',\
+         'alt_text':'a square logo of a Sunbird'}\
   }\
 }
 

--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -116,7 +116,10 @@ mosip.partner.prependThumbprint=true
 mosip.datashare.partner.id=mpartner-default-resident
 mosip.datashare.policy.id=mpolicy-default-resident
 
-csrf.disabled=true
+# CSRF Security Configuration
+# List of URLs that are excluded from CSRF protection. These URLs can still require authentication.
+mosip.security.csrf-ignore-urls=/oauth2/**,/logout,/safetynet/**,/credentials/**,/credentialshare/**,/binding-otp,/wallet-binding,\
+  /get-token/**,/req/otp,/vid,/req/auth/**,/req/individualId/otp,/auth/*/token-login,/wallets/**
 # Delayed websub subscription. Default is 5 seconds in ms.
 mosip.event.delay-millisecs=5000
 # Websub re-subscription workaround for losing subscribed topic when MOSIP websub update or restart. Default is 5 minutes in ms.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issuer display now supports branded logos (image + alt text) for multiple credential types, so issuer logos appear in credential UIs.

* **Chores**
  * Updated credential display configs across mock identity, MOSIP ID, land registry, and insurance credentials to include logo metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->