### PR TITLE
[INJIWEB] Remove unused csrf config and add csrf ignore urls config from mimoto properties

### DIFF
--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -345,7 +345,7 @@ mosip.security.ignore-auth-urls=/safetynet/**,/actuator/**,/swagger-ui/**,/v3/ap
 
 # CSRF Security Configuration
 # List of URLs that are excluded from CSRF protection. These URLs can still require authentication.
-# Note: /auth/*/token-login,/wallets/** are excluded from CSRF protection since they are accessed by mimoto api-test scripts which currently do not support CSRF token handling. These can be removed from the list once the api-test scripts are updated to handle CSRF tokens. 
+# Note: /auth/*/token-login,/wallets/** are excluded from CSRF protection since they are accessed by mimoto api-test scripts which currently do not support CSRF token handling. These can be removed from the list once the api-test scripts are updated to handle CSRF tokens. JIRA ticket for automation update - https://mosip.atlassian.net/browse/MOSIP-44057
 # The endpoints used in mobile wallet are also excluded since CSRF attacks are a browser specific vulnerability.
 mosip.security.csrf-ignore-urls=/oauth2/**,/logout,/safetynet/**,/credentials/**,/credentialshare/**,/binding-otp,/wallet-binding,\
   /get-token/**,/auth/*/token-login,/wallets/**

--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -125,7 +125,6 @@ mosip.partner.prependThumbprint=true
 mosip.datashare.partner.id=mpartner-default-resident
 mosip.datashare.policy.id=mpolicy-default-resident
 
-csrf.disabled=true
 # Delayed websub subscription. Default is 5 seconds in ms.
 mosip.event.delay-millisecs=5000
 # Websub re-subscription workaround for losing subscribed topic when MOSIP websub update or restart. Default is 5 minutes in ms.
@@ -343,3 +342,8 @@ mosip.security.ignore-auth-urls=/safetynet/**,/actuator/**,/swagger-ui/**,/v3/ap
   /allProperties,/credentials/**,/credentialshare/**,/binding-otp,/wallet-binding,/get-token/**,\
   /issuers,/issuers/**,/authorize,/req/otp,/vid,/req/auth/**,/req/individualId/otp,/aid/get-individual-id,\
  /verifiers, /auth/*/token-login
+
+# CSRF Security Configuration
+# List of URLs that are excluded from CSRF protection. These URLs can still require authentication.
+mosip.security.csrf-ignore-urls=/oauth2/**,/logout,/safetynet/**,/credentials/**,/credentialshare/**,/binding-otp,/wallet-binding,\
+  /get-token/**,/req/otp,/vid,/req/auth/**,/req/individualId/otp,/auth/*/token-login,/wallets/**

--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -346,4 +346,4 @@ mosip.security.ignore-auth-urls=/safetynet/**,/actuator/**,/swagger-ui/**,/v3/ap
 # CSRF Security Configuration
 # List of URLs that are excluded from CSRF protection. These URLs can still require authentication.
 mosip.security.csrf-ignore-urls=/oauth2/**,/logout,/safetynet/**,/credentials/**,/credentialshare/**,/binding-otp,/wallet-binding,\
-  /get-token/**,/req/otp,/vid,/req/auth/**,/req/individualId/otp,/auth/*/token-login,/wallets/**
+  /get-token/**,/req/otp,/auth/*/token-login,/wallets/**

--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -345,6 +345,7 @@ mosip.security.ignore-auth-urls=/safetynet/**,/actuator/**,/swagger-ui/**,/v3/ap
 
 # CSRF Security Configuration
 # List of URLs that are excluded from CSRF protection. These URLs can still require authentication.
-# Note: /auth/*/token-login,/wallets/** are excluded from CSRF protection since they are accessed by mimoto api-test scripts which currently do not support CSRF token handling. These can be removed from the list once the api-test scripts are updated to handle CSRF tokens.
+# Note: /auth/*/token-login,/wallets/** are excluded from CSRF protection since they are accessed by mimoto api-test scripts which currently do not support CSRF token handling. These can be removed from the list once the api-test scripts are updated to handle CSRF tokens. 
+# The endpoints used in mobile wallet are also excluded since CSRF attacks are a browser specific vulnerability.
 mosip.security.csrf-ignore-urls=/oauth2/**,/logout,/safetynet/**,/credentials/**,/credentialshare/**,/binding-otp,/wallet-binding,\
   /get-token/**,/auth/*/token-login,/wallets/**

--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -345,5 +345,6 @@ mosip.security.ignore-auth-urls=/safetynet/**,/actuator/**,/swagger-ui/**,/v3/ap
 
 # CSRF Security Configuration
 # List of URLs that are excluded from CSRF protection. These URLs can still require authentication.
+# Note: /auth/*/token-login,/wallets/** are excluded from CSRF protection since they are accessed by mimoto api-test scripts which currently do not support CSRF token handling. These can be removed from the list once the api-test scripts are updated to handle CSRF tokens.
 mosip.security.csrf-ignore-urls=/oauth2/**,/logout,/safetynet/**,/credentials/**,/credentialshare/**,/binding-otp,/wallet-binding,\
-  /get-token/**,/req/otp,/auth/*/token-login,/wallets/**
+  /get-token/**,/auth/*/token-login,/wallets/**


### PR DESCRIPTION
Introduce CSRF ignore configuration for mimoto service. The URLs mentioned in it will not require CSRF token to be passed to call it. GET endpoints are by default ignored in CSRF check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSRF protection tightened: global disablement removed so most endpoints are now protected by default.
  * Explicit exclusions added for specific authentication, OAuth, logout, OTP/token-login and wallet routes to preserve required flows while maintaining overall security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->