### PR TITLE
Remove unused locale 'hi' from accepted-locales

### DIFF
--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -75,7 +75,7 @@ logging.level.root=INFO
 ## Kyc Accepted Claims
 mosip.certify.ida.kyc-exchange.accepted-claims=birthdate,address,gender,name,phone_number,picture,email,individual_id
 ## Kyc Accepted Locales
-mosip.certify.ida.kyc-exchange.accepted-locales=en,hi,fr
+mosip.certify.ida.kyc-exchange.accepted-locales=en
 ## Add velocity template specific configurations
 mosip.certify.data-provider-plugin.velocity-template.env-configs.uin_length=10
 mosip.certify.data-provider-plugin.velocity-template.env-configs.vid_length=16


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * KYC exchange processing now supports English locale only, instead of English, Hindi, and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->