### PR TITLE
Update accepted locales in properties file

### DIFF
--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -75,7 +75,7 @@ logging.level.root=INFO
 ## Kyc Accepted Claims
 mosip.certify.ida.kyc-exchange.accepted-claims=birthdate,address,gender,name,phone_number,picture,email,individual_id
 ## Kyc Accepted Locales
-mosip.certify.ida.kyc-exchange.accepted-locales=en,hi
+mosip.certify.ida.kyc-exchange.accepted-locales=en
 ## Add velocity template specific configurations
 mosip.certify.data-provider-plugin.velocity-template.env-configs.uin_length=10
 mosip.certify.data-provider-plugin.velocity-template.env-configs.vid_length=16


### PR DESCRIPTION
Remove 'hi' from accepted locales for KYC exchange.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * KYC exchange functionality now supports English language only. Hindi language support has been disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->