### PR TITLE
[INJIWEB-1883] update variable name for mimoto database host and port

### DIFF
--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -234,9 +234,9 @@ mosip.kernel.keymanager.autogen.basekeys.list=MIMOTO:user_pii
 mosip.kernel.keymgr.hsm.health.check.enabled=false
 zkcrypto.random.key.generate.count=0
 
-mosip.mimoto.database.hostname=postgres-postgresql.postgres
+inji.mimoto.database.hostname=postgres-postgresql.postgres
 keymanager.persistence.jdbc.driver=org.postgresql.Driver
-keymanager_database_url = jdbc:postgresql://${mosip.mimoto.database.hostname}:${mosip.mimoto.database.port}/inji_mimoto
+keymanager_database_url = jdbc:postgresql://${inji.mimoto.database.hostname}:${inji.mimoto.database.port}/inji_mimoto
 keymanager_database_password=${db.dbuser.password}
 keymanager_database_username= mimotouser
 keymanager.persistence.jdbc.schema=mimoto


### PR DESCRIPTION
Update variable name for mimoto database host and port to use "inji" prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database connection configuration to align with updated naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->