### PR TITLE
[INJIWEB-1883] Update the database variable name in mimoto-default config

### DIFF
--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -248,9 +248,9 @@ mosip.kernel.keymanager.autogen.appids.list=ROOT,BASE,MIMOTO
 mosip.kernel.keymanager.autogen.basekeys.list=MIMOTO:user_pii
 zkcrypto.random.key.generate.count=0
 
-mosip.mimoto.database.hostname=postgres-postgresql.postgres
+inji.mimoto.database.hostname=postgres-postgresql.postgres
 keymanager.persistence.jdbc.driver=org.postgresql.Driver
-keymanager_database_url = jdbc:postgresql://${mosip.mimoto.database.hostname}:${mosip.mimoto.database.port}/inji_mimoto
+keymanager_database_url = jdbc:postgresql://${inji.mimoto.database.hostname}:${inji.mimoto.database.port}/inji_mimoto
 keymanager_database_password=${db.dbuser.password}
 keymanager_database_username= mimotouser
 keymanager.persistence.jdbc.schema=mimoto


### PR DESCRIPTION
Deployment variable names are changed :  

MOSIP_MIMOTO_DATABASE_HOSTNAME -> INJI_MIMOTO_DATABASE_HOSTNAME
MOSIP_MIMOTO_DATABASE_PORT -> INJI_MIMOTO_DATABASE_PORT