### PR TITLE
Update did-url in certify-mosipid-identity.properties

### DIFF
--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -23,7 +23,7 @@ mosip.certify.ida.kyc-exchange-id=mosip.identity.kycexchange
 mosip.certify.authenticator.ida-version=1.0
 mosip.certify.authenticator.ida.kyc-exchange-url=https://${mosip.api.cre.internal.host}/idauthentication/v1/kyc-exchange/delegated/${mosip.certify.misp.license.key}/
 
-mosip.certify.data-provider-plugin.did-url=did:web:inji.github.io:inji-config:qa-inji1:mosipid-identity
+mosip.certify.data-provider-plugin.did-url=did:web:inji.github.io:inji-config:released:mosipid-identity
 mosip.certify.data-provider-plugin.id-field-prefix-uri=https://mosip.io/credential/
 
 mosip.certify.misp.license.key=${mosip.certify.misp.key}


### PR DESCRIPTION
updated did.url to did:web:inji.github.io:inji-config:released:mosipid-identity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mosip-identity data provider configuration to reference the released environment instead of QA configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->