### PR TITLE
INJICERT-1185: Config dependency for did url is still exists 

### DIFF
--- a/certify-csvdp-farmer.properties
+++ b/certify-csvdp-farmer.properties
@@ -19,7 +19,7 @@ mosip.certify.rendering-template.cache-max-age-days=1
 ## ------------------------------------------- Plugin specific usecase properties ------------------------------------------------------------
 # Other supported value: [RsaSignature2018]
 mosip.certify.status-list.signature-crypto-suite=Ed25519Signature2020
-mosip.certify.data-provider-plugin.did-url=did:web:inji.github.io:inji-config:dev-int-inji:farmer
+mosip.certify.data-provider-plugin.did-url=did:web:${mosip.injicertify.farmer.host}
 mosip.certify.data-provider-plugin.rendering-template-id=5b9c2a12-810a-7388-2dc8-13ee7ad88bac
 mosip.certify.data-provider-plugin.id-field-prefix-uri=https://mosip.io/credential/
 

--- a/certify-mock-identity.properties
+++ b/certify-mock-identity.properties
@@ -17,7 +17,7 @@ mosip.certify.rendering-template.cache-max-age-days=1
 
 ## ------------------------------------------- Plugin specific usecase properties ------------------------------------------------------------
 mosip.certify.status-list.signature-crypto-suite=Ed25519Signature2020
-mosip.certify.data-provider-plugin.did-url=did:web:inji.github.io:inji-config:dev-int-inji:mock-identity
+mosip.certify.data-provider-plugin.did-url=did:web:${mosip.injicertify.mock.host}
 mosip.certify.mock.authenticator.get-identity-url=https://${mosip.api.mockidentitysystem.host}/v1/mock-identity-system/identity
 
 ## ------------------------------------------- UseCase specific default overriding properties ------------------------------------------------------------

--- a/certify-postgres-landregistry.properties
+++ b/certify-postgres-landregistry.properties
@@ -32,7 +32,7 @@ mosip.certify.indexed-mappings.holderName=$.holder_name
 
 # Other supported value: [RsaSignature2018]
 mosip.certify.status-list.signature-crypto-suite=Ed25519Signature2020
-mosip.certify.data-provider-plugin.did-url=did:web:inji.github.io:inji-config:dev-int-inji:landregistry
+mosip.certify.data-provider-plugin.did-url=did:web:${mosip.injicertify.landregistry.host}
 # below property to be removed in next release
 mosip.certify.data-provider-plugin.rendering-template-id=5b9c2a12-810a-7388-2dc8-13ee7ad88bac
 # below property to be removed in next release -- temporary workaround -> INJIWEB-1202

--- a/certify-postgres-truckpass.properties
+++ b/certify-postgres-truckpass.properties
@@ -25,7 +25,7 @@ mosip.certify.data-provider-plugin.postgres.scope-query-mapping={\
 
 # Other supported value: [RsaSignature2018]
 mosip.certify.status-list.signature-crypto-suite=Ed25519Signature2020
-mosip.certify.data-provider-plugin.did-url=did:web:mosip.github.io:inji-config:dev-int-inji:truckpass
+mosip.certify.data-provider-plugin.did-url=did:web:${mosip.injicertify.truckpass.host}
 mosip.certify.data-provider-plugin.id-field-prefix-uri=https://mosip.io/credential/
 
 ## ------------------------------------------- Plugin enable properties ------------------------------------------------------------

--- a/certify-postgres-university.properties
+++ b/certify-postgres-university.properties
@@ -17,7 +17,7 @@ mosip.certify.rendering-template.cache-max-age-days=1
 
 ## ------------------------------------------- Plugin specific usecase properties ------------------------------------------------------------
 mosip.certify.status-list.signature-crypto-suite=Ed25519Signature2020
-mosip.certify.data-provider-plugin.did-url=did:web:inji.github.io:inji-config:dev-int-inji:academic
+mosip.certify.data-provider-plugin.did-url=did:web:${mosip.injicertify.university.host}
 mosip.certify.data-provider-plugin.rendering-template-id=5b9c2a12-810a-7388-2dc8-13ee7ad88bac
 mosip.certify.data-provider-plugin.id-field-prefix-uri=https://mosip.io/credential/
 


### PR DESCRIPTION
### Description

- updated did url config for all use-cases to test on dev-int-inji env

1. farmer
2. mock identity
3. land registry
4. academic
5. truckpass