### PR TITLE
[DSD-10224] Add v2/issuers path in auth ignore URLs

### DIFF
--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -341,7 +341,7 @@ mosip.injiweb.mask.disclosures=true
 mosip.security.ignore-auth-urls=/safetynet/**,/actuator/**,/swagger-ui/**,/v3/api-docs/**,\
   /allProperties,/credentials/**,/credentialshare/**,/binding-otp,/wallet-binding,/get-token/**,\
   /issuers,/issuers/**,/authorize,/req/otp,/vid,/req/auth/**,/req/individualId/otp,/aid/get-individual-id,\
- /verifiers, /auth/*/token-login
+ /verifiers, /auth/*/token-login,/v2/issuers,/v2/issuers/**
 
 # CSRF Security Configuration
 # List of URLs that are excluded from CSRF protection. These URLs can still require authentication.


### PR DESCRIPTION
Add v2/issuers path in auth ignore URLs so that token is not required to access it. Required for accessing the API in Guest mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication configuration to allow public access to issuer endpoints. The issuer information service and all associated subpaths are now accessible without authentication, enabling open discovery and retrieval of issuer data without requiring user credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->