### PR TITLE
Updated vc+sd-jwt to dc+sd-jwt in cryptographic-binding-methods-supported 

### DIFF
--- a/certify-default.properties
+++ b/certify-default.properties
@@ -183,7 +183,7 @@ mosip.certify.allow-c-nonce=true
 mosip.certify.credential-config.cryptographic-binding-methods-supported={\
   'ldp_vc': {'did:jwk','did:key'},\
   'mso_mdoc': {'cose_key'},\
-  'vc+sd-jwt': {'did:jwk','did:key'}\
+  'dc+sd-jwt': {'did:jwk','did:key'}\
 }
 mosip.certify.credential-config.credential-signing-alg-values-supported={\
   'RsaSignature2018': {'RS256'},\


### PR DESCRIPTION
## Description
Updated the value from dc+sd-jwt to vc+sd-jwt in `mosip.certify.credential-config.cryptographic-binding-methods-supported` property in `certify-default.properties` file