### PR TITLE
DSD-10406: Update certify-default.properties with RNG provider setting

### DIFF
--- a/certify-default.properties
+++ b/certify-default.properties
@@ -245,3 +245,6 @@ mosip.bio.image.compressor.resize.factor.fy=0.25
 mosip.bio.image.compressor.compression.ratio=50
 mosip.certify.image-compressor.image.max-allowed-size=1024
 mosip.certify.image-compressor.image.max-retry-attempts=3
+
+#disable rng provider while generating the SecureRandom
+mosip.kernel.keygenerator.rng.provider.enable=false


### PR DESCRIPTION
[DSD-10406]
Added configuration to disable RNG provider for SecureRandom generation.