### PR TITLE
feat: add MockDPoP issuer for DPoP token binding testing

### DIFF
--- a/mimoto-issuers-config.json
+++ b/mimoto-issuers-config.json
@@ -201,6 +201,33 @@
       "enabled": "true"
     },
     {
+      "issuer_id": "MockDPoP",
+      "credential_issuer": "MockDPoP",
+      "credential_issuer_host": "https://${mosip.injicertify.mock.host}",
+      "display": [
+        {
+          "name": "Mock Identity (DPoP)",
+          "logo": {
+            "url": "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+            "alt_text": "mosip-logo"
+          },
+          "title": "Mock Identity (DPoP)",
+          "description": "Download Mock Identity Credential via DPoP",
+          "language": "en"
+        }
+      ],
+      "protocol": "OpenId4VCI",
+      "client_id": "${mimoto.oidc.mock.partner.clientid}",
+      "client_alias": "mpartner-default-mimoto-mock-oidc",
+      "wellknown_endpoint": "https://${mosip.injicertify.mock.host}/v1/certify/issuance/.well-known/openid-credential-issuer",
+      "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
+      "authorization_audience": "https://esignet.esqa2.mosip.net/v1/esignet/oauth/v2/token",
+      "token_endpoint": "https://${mosip.api.public.host}/v1/mimoto/v2/get-token/MockDPoP",
+      "proxy_token_endpoint": "https://esignet.esqa2.mosip.net/v1/esignet/oauth/v2/token",
+      "qr_code_type": "OnlineSharing",
+      "enabled": "true"
+    },
+    {
       "issuer_id": "Land",
       "credential_issuer": "Land",
       "credential_issuer_host": "https://${mosip.injicertify.landregistry.host}",


### PR DESCRIPTION
## Summary

Adds a `MockDPoP` issuer as a duplicate of the existing `Mock` issuer, but using the new `/v2/get-token/` endpoint which supports DPoP (RFC 9449) token binding.

## Changes

- `mimoto-issuers-config.json`: Added `MockDPoP` issuer entry after `Mock`

## Key difference from Mock issuer

| Field | Mock | MockDPoP |
|-------|------|----------|
| `issuer_id` | `Mock` | `MockDPoP` |
| `token_endpoint` | `.../v1/mimoto/get-token/Mock` | `.../v1/mimoto/v2/get-token/MockDPoP` |
| Display name | Mock Identity | Mock Identity (DPoP) |

## Purpose

The `/v2/get-token/{issuer}` endpoint (added in Mimoto PR [#1097](https://github.com/inji/mimoto/pull/1097)) handles DPoP proof forwarding and token binding per RFC 9449. This issuer config enables testing DPoP end-to-end in dev-int with the same Mock certify stack.