### PR TITLE
fix: override issuer-uri in mock certify config for eSignet v1.8+

### DIFF
--- a/certify-mock-identity.properties
+++ b/certify-mock-identity.properties
@@ -46,3 +46,5 @@ mosip.certify.indexed-mappings.postalCode=$.postalCode
 # When the revocation is enabled for a vc-type but ledger is disabled, then the user should have their own mechanism to identity the statusListCredentialId and statusListIndex.
 # Enabling the ledger flag is highly recommended to search for the issued credentials.
 mosip.certify.issuer.ledger-enabled=true
+# Override issuer-uri: eSignet v1.8+ (esqa2) sets iss = base URL (without /v1/esignet context path)
+mosip.certify.authn.issuer-uri=https://esignet.esqa2.mosip.net


### PR DESCRIPTION




## Related

- Mimoto PR: https://github.com/inji/mimoto/pull/1097 (DPoP v2 token endpoint)