### PR TITLE
feat(collab): add did:web document for ph4h use case

### DIFF
--- a/collab/ph4h/did.json
+++ b/collab/ph4h/did.json
@@ -1,0 +1,23 @@
+{
+  "assertionMethod": [
+    "did:web:inji.github.io:inji-config:collab:ph4h"
+  ],
+  "service": [],
+  "id": "did:web:inji.github.io:inji-config:collab:ph4h",
+  "verificationMethod": [
+    {
+      "publicKeyMultibase": "z6Mkp4oZgsQa2GLvhTKF68UqK6JaFUJ5jo3j2FoGUBwqCBZs",
+      "controller": "did:web:inji.github.io:inji-config:collab:ph4h",
+      "id": "did:web:inji.github.io:inji-config:collab:ph4h#lsiq7t4D32EObAH6ZmVlsY9_A4MupYWG8SL93x1GAXs",
+      "type": "Ed25519VerificationKey2020",
+      "@context": "https://w3id.org/security/suites/ed25519-2020/v1"
+    }
+  ],
+  "@context": [
+    "https://www.w3.org/ns/did/v1"
+  ],
+  "alsoKnownAs": [],
+  "authentication": [
+    "did:web:inji.github.io:inji-config:collab:ph4h"
+  ]
+}


### PR DESCRIPTION
## What
Adds the DID document for `did:web:inji.github.io:inji-config:collab:ph4h`, hosted via GitHub Pages at:
`https://inji.github.io/inji-config/collab/ph4h/did.json`

## File added
`collab/ph4h/did.json`