### PR TITLE
Remove spec_version from trusted verifiers

### DIFF
--- a/mimoto-trusted-verifiers.json
+++ b/mimoto-trusted-verifiers.json
@@ -8,7 +8,6 @@
       "response_uris": [
         "https://${mosip.injiverify.host}/v1/verify/v2/vp-submission/direct-post"
       ],
-      "spec_version": "v1",
       "allow_unsigned_request": true
     },
     {
@@ -19,7 +18,6 @@
       "response_uris": [
         "https://${mosip.injiverify.host}/v1/verify/vp-submission/direct-post"
       ],
-      "spec_version": "draft23",
       "allow_unsigned_request": true
     },
     {
@@ -61,7 +59,6 @@
       "response_uris": [
         "https://injiverify.collab.mosip.net/v1/verify/vp-submission/direct-post"
       ],
-      "spec_version": "draft23",
       "jwks_uri": "https://injiverify.collab.mosip.net/.well-known/jwks.json",
       "allow_unsigned_request": true
     },


### PR DESCRIPTION
Removed 'spec_version' fields from multiple entries.